### PR TITLE
Change Mongo DB name to match service name

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -59,7 +59,7 @@ play.http.router=prod.Routes
 # mongo
 
 mongodb {
-    uri = "mongodb://localhost:27017/pla_stub"
+    uri = "mongodb://localhost:27017/pla-dynamic-stub"
 }
 
 # Controller


### PR DESCRIPTION
Name of the Mongo DB used by the stub is different for local and staging environments. This caused a lot of wasted developer time when making changes to staging test data, as it is expected and true for all other services to use the same DB name in all environments.

This commit changes the DB name to be the same as the service name, which is a common practise throughout the platform.
